### PR TITLE
Fix simple output string parsing

### DIFF
--- a/carta/__main__.py
+++ b/carta/__main__.py
@@ -148,7 +148,7 @@ class ReMarkable:
         out = ()
 
         if stdout:
-            stdout = stdout.decode("utf-8").strip().split(": ")[1:]
+            stdout = list(map(str.strip, stdout.decode("utf-8").strip().split(":")))[1:]
 
             if len(stdout) == 1:  # Button
                 out = (stdout[0], True)


### PR DESCRIPTION
Fixes: textinput identifier has trailing space in result tuple.
Fixes: textinput was treated as a button if submitted as an empty string.